### PR TITLE
Null safety migration

### DIFF
--- a/dio_retry/lib/src/options.dart
+++ b/dio_retry/lib/src/options.dart
@@ -41,7 +41,7 @@ class RetryOptions {
   /// Returns [true] only if the response hasn't been cancelled or got
   /// a bas status code.
   static FutureOr<bool> defaultRetryEvaluator(DioError error) {
-    return error.type != DioErrorType.CANCEL && error.type != DioErrorType.RESPONSE;
+    return error.type != DioErrorType.cancel && error.type != DioErrorType.response;
   }
 
   factory RetryOptions.fromExtra(RequestOptions request) {
@@ -70,7 +70,7 @@ class RetryOptions {
   }
 
   Options mergeIn(Options options) {
-    return options.merge(
+    return options.copyWith(
       extra: <String,dynamic>{}
         ..addAll(options.extra ?? {})
         ..addAll(this.toExtra())

--- a/dio_retry/pubspec.yaml
+++ b/dio_retry/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/aloisdeniel/dio_retry
 author: aloisdeniel <alois.deniel@outlook.com>
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.1.6
-  logging: ^0.11.3
-  dio: ^3.0.0
+  meta: ^1.3.0
+  logging: ^1.0.1
+  dio: ^4.0.0
 
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: ^1.11.0
+  test: ^1.16.8


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+`
* Update of dependencies to theirs own null safety versions
  * meta: `1.1.6` -> `1.3.0`
  * logging: `0.11.3` -> `1.0.1`
  * dio: `3.0.0` -> `4.0.0`
  * pedantic: `1.0.0` -> `1.11.0`
  * test: `1.0.0` -> `1.16.8`
* Update of code to manage  `dio 4.0.0`

## Testing
- [x] Tested manually the example 