### PR TITLE
Null safety & dio 4.+ migration

### DIFF
--- a/dio_retry/example/example.dart
+++ b/dio_retry/example/example.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:dio_retry/dio_retry.dart';
 import 'package:logging/logging.dart';
 
-main() async {
+void main() async {
   // Displaying logs
   Logger.root.level = Level.ALL;
   Logger.root.onRecord.listen((record) {
@@ -14,16 +14,14 @@ main() async {
   // Add the interceptor with optional options
   dio.interceptors.add(RetryInterceptor(
     dio: dio,
-    logger: Logger("Retry"),
-    options: const RetryOptions(
-      retryInterval: const Duration(seconds: 5),
-    ),
+    logger: Logger('Retry'),
+    options: const RetryOptions(retryInterval: Duration(seconds: 5)),
   ));
 
   /// Sending a failing request for 3 times with a 5s interval
   try {
-    await dio.get("http://www.mqldkfjmdisljfmlksqdjfmlkj.dev");
+    await dio.get('http://www.mqldkfjmdisljfmlksqdjfmlkj.dev');
   } catch (e) {
-    print("End error : $e");
+    print('End error : $e');
   }
 }

--- a/dio_retry/lib/src/options.dart
+++ b/dio_retry/lib/src/options.dart
@@ -41,7 +41,7 @@ class RetryOptions {
   /// Returns [true] only if the response hasn't been cancelled or got
   /// a bas status code.
   static FutureOr<bool> defaultRetryEvaluator(DioError error) {
-    return error.type != DioErrorType.CANCEL && error.type != DioErrorType.RESPONSE;
+    return error.type != DioErrorType.cancel && error.type != DioErrorType.response;
   }
 
   factory RetryOptions.fromExtra(RequestOptions request) {
@@ -70,7 +70,7 @@ class RetryOptions {
   }
 
   Options mergeIn(Options options) {
-    return options.merge(
+    return options.copyWith(
       extra: <String,dynamic>{}
         ..addAll(options.extra ?? {})
         ..addAll(this.toExtra())

--- a/dio_retry/lib/src/options.dart
+++ b/dio_retry/lib/src/options.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
-
 import 'package:dio/dio.dart';
 
-typedef FutureOr<bool> RetryEvaluator(DioError error);
+typedef RetryEvaluator = FutureOr<bool> Function(DioError error);
 
 class RetryOptions {
   /// The number of retry in case of an error
@@ -11,32 +10,24 @@ class RetryOptions {
   /// The interval before a retry.
   final Duration retryInterval;
 
-  /// Evaluating if a retry is necessary.regarding the error. 
-  /// 
-  /// It can be a good candidate for additional operations too, like 
-  /// updating authentication token in case of a unauthorized error (be careful 
-  /// with concurrency though). 
-  /// 
+  /// Evaluating if a retry is necessary.regarding the error.
+  ///
+  /// It can be a good candidate for additional operations too, like
+  /// updating authentication token in case of a unauthorized error (be careful
+  /// with concurrency though).
+  ///
   /// Defaults to [defaultRetryEvaluator].
-  RetryEvaluator get retryEvaluator => this._retryEvaluator ?? defaultRetryEvaluator;
+  RetryEvaluator get retryEvaluator => _retryEvaluator ?? defaultRetryEvaluator;
 
-  final RetryEvaluator _retryEvaluator;
+  final RetryEvaluator? _retryEvaluator;
 
-  const RetryOptions(
-      {this.retries = 3,
-      RetryEvaluator retryEvaluator,
-      this.retryInterval = const Duration(seconds: 1)})
-      : assert(retries != null),
-        assert(retryInterval != null),
-        this._retryEvaluator = retryEvaluator;
+  const RetryOptions({this.retries = 3, RetryEvaluator? retryEvaluator, this.retryInterval = const Duration(seconds: 1)}) : _retryEvaluator = retryEvaluator;
 
   factory RetryOptions.noRetry() {
-    return RetryOptions(
-      retries: 0,
-    );
+    return RetryOptions(retries: 0);
   }
 
-  static const extraKey = "cache_retry_request";
+  static const extraKey = 'cache_retry_request';
 
   /// Returns [true] only if the response hasn't been cancelled or got
   /// a bas status code.
@@ -44,36 +35,26 @@ class RetryOptions {
     return error.type != DioErrorType.cancel && error.type != DioErrorType.response;
   }
 
-  factory RetryOptions.fromExtra(RequestOptions request) {
+  static RetryOptions? fromExtra(RequestOptions request) {
     return request.extra[extraKey];
   }
 
-  RetryOptions copyWith({
-    int retries,
-    Duration retryInterval,
-  }) =>
-      RetryOptions(
-        retries: retries ?? this.retries,
-        retryInterval: retryInterval ?? this.retryInterval,
-      );
+  RetryOptions copyWith({int? retries, Duration? retryInterval}) {
+    return RetryOptions(
+      retries: retries ?? this.retries,
+      retryInterval: retryInterval ?? this.retryInterval,
+    );
+  }
 
   Map<String, dynamic> toExtra() {
-    return {
-      extraKey: this,
-    };
+    return {extraKey: this};
   }
 
   Options toOptions() {
-    return Options(
-      extra: this.toExtra()
-    );
+    return Options(extra: toExtra());
   }
 
   Options mergeIn(Options options) {
-    return options.copyWith(
-      extra: <String,dynamic>{}
-        ..addAll(options.extra ?? {})
-        ..addAll(this.toExtra())
-    );
+    return options.copyWith(extra: <String, dynamic>{}..addAll(options.extra ?? {})..addAll(toExtra()));
   }
 }

--- a/dio_retry/lib/src/options.dart
+++ b/dio_retry/lib/src/options.dart
@@ -1,5 +1,27 @@
 import 'dart:async';
+
 import 'package:dio/dio.dart';
+
+extension RequestOptionsExtensions on RequestOptions {
+  Options toOptions() {
+    return Options(
+      method: method,
+      sendTimeout: sendTimeout,
+      receiveTimeout: receiveTimeout,
+      extra: extra,
+      headers: headers,
+      responseType: responseType,
+      contentType: contentType,
+      validateStatus: validateStatus,
+      receiveDataWhenStatusError: receiveDataWhenStatusError,
+      followRedirects: followRedirects,
+      maxRedirects: maxRedirects,
+      requestEncoder: requestEncoder,
+      responseDecoder: responseDecoder,
+      listFormat: listFormat,
+    );
+  }
+}
 
 typedef RetryEvaluator = FutureOr<bool> Function(DioError error);
 

--- a/dio_retry/lib/src/retry_interceptor.dart
+++ b/dio_retry/lib/src/retry_interceptor.dart
@@ -1,50 +1,66 @@
 import 'package:dio/dio.dart';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 
 import 'options.dart';
 
 /// An interceptor that will try to send failed request again
 class RetryInterceptor extends Interceptor {
   final Dio dio;
-  final Logger logger;
+  final Logger? logger;
   final RetryOptions options;
 
-  RetryInterceptor({@required this.dio, this.logger, RetryOptions options})
-      : this.options = options ?? const RetryOptions();
+  RetryInterceptor({required this.dio, this.logger, RetryOptions? options}) : options = options ?? const RetryOptions();
 
   @override
-  Future  onError(DioError err, ErrorInterceptorHandler handler) async {
-    var extra = RetryOptions.fromExtra(err.requestOptions) ?? this.options;
+  Future onError(DioError err, ErrorInterceptorHandler handler) async {
+    var extra = RetryOptions.fromExtra(err.requestOptions) ?? options;
 
-    var shouldRetry = extra.retries > 0 && await extra.retryEvaluator(err);
-    if (shouldRetry) {
-      if (extra.retryInterval.inMilliseconds > 0) {
-        await Future.delayed(extra.retryInterval);
-      }
-
-      // Update options to decrease retry count before new try
-      extra = extra.copyWith(retries: extra.retries - 1);
-      err.requestOptions.extra = err.requestOptions.extra..addAll(extra.toExtra());
-
-      try {
-        logger?.warning(
-            "[${err.requestOptions.uri}] An error occured during request, trying a again (remaining tries: ${extra.retries}, error: ${err.error})");
-        // We retry with the updated options
-       return await this.dio.request(
-          err.requestOptions.path,
-          cancelToken: err.requestOptions.cancelToken,
-          data: err.requestOptions.data,
-          onReceiveProgress: err.requestOptions.onReceiveProgress,
-          onSendProgress: err.requestOptions.onSendProgress,
-          queryParameters: err.requestOptions.queryParameters,
-          options: extra.toOptions()
-        );
-      } catch (e) {
-        return e;
-      }
+    final shouldRetry = extra.retries > 0 && await options.retryEvaluator(err);
+    if (!shouldRetry) {
+      return super.onError(err, handler);
     }
 
-    return super.onError(err, handler);
+    if (extra.retryInterval.inMilliseconds > 0) {
+      await Future.delayed(extra.retryInterval);
+    }
+
+    // Update options to decrease retry count before new try
+    extra = extra.copyWith(retries: extra.retries - 1);
+    err.requestOptions.extra = err.requestOptions.extra..addAll(extra.toExtra());
+
+    try {
+      logger?.warning('[${err.requestOptions.uri}] An error occurred during request, trying a again (remaining tries: ${extra.retries}, error: ${err.error})');
+      // We retry with the updated options
+      return await dio.request(
+        err.requestOptions.path,
+        cancelToken: err.requestOptions.cancelToken,
+        data: err.requestOptions.data,
+        onReceiveProgress: err.requestOptions.onReceiveProgress,
+        onSendProgress: err.requestOptions.onSendProgress,
+        queryParameters: err.requestOptions.queryParameters,
+        options: toOptions(err.requestOptions),
+      );
+    } catch (e) {
+      return e;
+    }
+  }
+
+  Options toOptions(RequestOptions o) {
+    return Options(
+      method: o.method,
+      sendTimeout: o.sendTimeout,
+      receiveTimeout: o.receiveTimeout,
+      extra: o.extra,
+      headers: o.headers,
+      responseType: o.responseType,
+      contentType: o.contentType,
+      validateStatus: o.validateStatus,
+      receiveDataWhenStatusError: o.receiveDataWhenStatusError,
+      followRedirects: o.followRedirects,
+      maxRedirects: o.maxRedirects,
+      requestEncoder: o.requestEncoder,
+      responseDecoder: o.responseDecoder,
+      listFormat: o.listFormat,
+    );
   }
 }

--- a/dio_retry/pubspec.yaml
+++ b/dio_retry/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/aloisdeniel/dio_retry
 author: aloisdeniel <alois.deniel@outlook.com>
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.1.6
-  logging: ^0.11.3
-  dio: ^3.0.0
+  meta: ^1.3.0
+  logging: ^1.0.1
+  dio: ^4.0.0
 
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: ^1.11.0
+  test: ^1.16.8


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) and [fix a bug on the retry callback detection](https://github.com/aloisdeniel/dio_retry/issues/4)

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+` (required for the null safety migration)
* Migrate to dio 4.0 (required for the null safety migration)
* Fix this bug [https://github.com/aloisdeniel/dio_retry/issues/4](url)

## Testing
- [x] Tested manually the example 

### Related tickets
- Open #4 
- Open #9 
- Open #10